### PR TITLE
DC-10905 : Changed `item(at indexPath: IndexPath)` in `RealmStorage` 

### DIFF
--- a/DTModelStorage.podspec
+++ b/DTModelStorage.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors  = { 'Denys Telezhkin' => 'denys.telezhkin.oss@gmail.com' }
   s.source   = { :git => 'https://github.com/DenTelezhkin/DTModelStorage.git', :tag => s.version.to_s }
   s.requires_arc = true
-  s.swift_versions = ["4.0", "4.2", "5.0"]
+#  s.swift_versions= ['4.0', '4.2', '5.0']
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.0'
   s.frameworks = 'UIKit', 'Foundation', 'CoreData'

--- a/DTModelStorage.podspec
+++ b/DTModelStorage.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors  = { 'Denys Telezhkin' => 'denys.telezhkin.oss@gmail.com' }
   s.source   = { :git => 'https://github.com/DenTelezhkin/DTModelStorage.git', :tag => s.version.to_s }
   s.requires_arc = true
-  s.swift_versions = ['4.0', '4.2', '5.0']
+  s.swift_version = '4.0', '4.2', '5.0'
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.0'
   s.frameworks = 'UIKit', 'Foundation', 'CoreData'

--- a/DTModelStorage.podspec
+++ b/DTModelStorage.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors  = { 'Denys Telezhkin' => 'denys.telezhkin.oss@gmail.com' }
   s.source   = { :git => 'https://github.com/DenTelezhkin/DTModelStorage.git', :tag => s.version.to_s }
   s.requires_arc = true
-  s.swift_version = ['4.0', '4.2', '5.0']
+  s.swift_versions = ["4.0", "4.2", "5.0"]
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.0'
   s.frameworks = 'UIKit', 'Foundation', 'CoreData'

--- a/DTModelStorage.podspec
+++ b/DTModelStorage.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors  = { 'Denys Telezhkin' => 'denys.telezhkin.oss@gmail.com' }
   s.source   = { :git => 'https://github.com/DenTelezhkin/DTModelStorage.git', :tag => s.version.to_s }
   s.requires_arc = true
-  s.swift_version = '4.0', '4.2', '5.0'
+  s.swift_version = ['4.0', '4.2', '5.0']
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.0'
   s.frameworks = 'UIKit', 'Foundation', 'CoreData'

--- a/Source/Core/Section.swift
+++ b/Source/Core/Section.swift
@@ -35,4 +35,14 @@ public protocol Section
     
     ///  Number of items in current section.
     var numberOfItems: Int { get }
+    
+    ///  Returns the object at the given index
+    subscript(_ index: Int) -> Any { get }
+}
+
+extension Section {
+    ///  Returns the object at the given index
+    public subscript(_ index: Int) -> Any {
+        return items[index]
+    }
 }

--- a/Source/Realm/RealmSection.swift
+++ b/Source/Realm/RealmSection.swift
@@ -67,4 +67,9 @@ open class RealmSection<T: RealmCollectionValue> : SupplementaryAccessible, Sect
     open var numberOfItems: Int {
         return results.count
     }
+    
+    /// Returns the object at the given index.
+    public subscript(_ index: Int) -> Any {
+        return results[index]
+    }
 }

--- a/Source/Realm/RealmStorage.swift
+++ b/Source/Realm/RealmStorage.swift
@@ -201,8 +201,9 @@ open class RealmStorage: BaseStorage, Storage, SupplementaryStorage, SectionLoca
         guard indexPath.section < sections.count else {
             return nil
         }
-        guard indexPath.item < sections[indexPath.section].items.count else { return nil }
-        return sections[indexPath.section].items[indexPath.item]
+        guard indexPath.item < sections[indexPath.section].numberOfItems else { return nil }
+        guard let section = section(at: indexPath.section) else { return nil }
+        return section[indexPath.item]
     }
     
     // MARK: - SupplementaryStorage


### PR DESCRIPTION
changed `item(at indexPath: IndexPath)` in `RealmStorage` so that it would access realm directly and get an object, instead of pulling the full result set into the `items` array.

To do this, we created a `subscript` operator in the `Section` protocol. So that everything works the way it used to, the default version of that is `items[index]`, which is part of a protocol extension to `Section`. In `RealmSection` we define `subscript` to look at `results[index]` instead.

Then in the `item(at indexPath: IndexPath)` routine for `RealmSection` we can say `return section[indexPath.item]`, which avoids the `items` array and uses Realm to get only the one single object.